### PR TITLE
Fixes it where it works in WordPress 4.7

### DIFF
--- a/pagetemplater.php
+++ b/pagetemplater.php
@@ -99,6 +99,10 @@ class PageTemplater {
                 // Replace existing value in cache
                 wp_cache_set( $cache_key, $templates, 'themes', 1800 );
 
+		add_filter( 'theme_page_templates', function( $page_templates ) use ( $templates ) {
+			return $templates;
+		});
+		
                 return $atts;
 
         } 


### PR DESCRIPTION
https://wptavern.com/wordpress-4-7-brings-custom-page-template-functionality-to-all-post-types talks all about it.